### PR TITLE
fix a trivial-case bug when using Yen

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
 name = "HistogramThresholding"
 uuid = "2c695a8d-9458-5d45-9878-1b8a99cf7853"
 authors = ["Dr. Zygmunt L. Szpak <zygmunt.szpak@gmail.com>"]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
-julia = "^1"
+julia = "1"
 
 [extras]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/src/yen.jl
+++ b/src/yen.jl
@@ -96,7 +96,7 @@ function find_threshold(algorithm::Yen, histogram::AbstractArray, edges::Abstrac
     Gₛ = 0
     G′ₛ = sum(p.^2)
     maxval = typemin(Float64)
-    t = 0
+    t = firstindex(edges)
     for s in eachindex(p[1:m-1])
         # Update sums.
         Pₛ += p[s]

--- a/test/yen.jl
+++ b/test/yen.jl
@@ -19,4 +19,8 @@
     t = find_threshold(Yen(), counts[1:end], edges)
     @test round(t*256) == 120
 
+    img = zeros(Gray{Float64},10,10,3)
+    edges, counts = build_histogram(img,  256)
+    t = find_threshold(Yen(), counts[1:end], edges)
+    @test t == 0.0
 end


### PR DESCRIPTION
When images are filled with only one value, the histogram becomes trivial.